### PR TITLE
Update qc-summary.template

### DIFF
--- a/resources/bcbio/qc-summary.template
+++ b/resources/bcbio/qc-summary.template
@@ -39,7 +39,7 @@ if (file.exists(tx2genes_file)) {
   names(sf_files) = rownames(summarydata)
   tx2gene = read.table(tx2genes_file, sep=",", row.names=NULL, header=FALSE)
   txi.salmon = tximport(sf_files, type="salmon", tx2gene=tx2gene,
-                        reader=readr::read_tsv)
+                        reader=readr::read_tsv, countsFromAbundance="scaledTPM")
   counts = data.frame(txi.salmon$counts)
 } else {
   loginfo("Using gene counts calculated from featureCounts.")


### PR DESCRIPTION
If you want to work only with the counts matrix, I'd recommend using the scaledTPM version. These counts are length-corrected across samples but otherwise on the original count scale.

The way we have DESeq2 and edgeR working with the estimated fragment counts directly -- [examples here](https://github.com/mikelove/tximport/blob/master/vignettes/tximport.md#import-with-edger-deseq2-limma-voom) -- is to have the average transcript length brought along as a modeling offset. [DESeqDataSetFromTximport](https://github.com/Bioconductor-mirror/DESeq2/blob/master/R/AllClasses.R#L324-L339) in the devel branch does this work for you.